### PR TITLE
fix credo warnings

### DIFF
--- a/lib/agents.ex
+++ b/lib/agents.ex
@@ -131,7 +131,7 @@ defmodule Certstream.ClientManager do
   end
 
   def broadcast_to_clients(entries) do
-    Logger.debug("Broadcasting #{length(entries)} certificates to clients")
+    Logger.debug(fn -> "Broadcasting #{length(entries)} certificates to clients" end)
 
     certificates = entries
       |> Enum.map(&(%{:message_type => "certificate_update", :data => &1}))

--- a/lib/ct_watcher.ex
+++ b/lib/ct_watcher.ex
@@ -78,11 +78,11 @@ defmodule Certstream.CTWatcher do
   end
 
   def handle_info(:update, state) do
-    Logger.debug("Worker #{inspect self()} got tick.")
+    Logger.debug(fn -> "Worker #{inspect self()} got tick." end)
 
     current_size = fetch_tree_size(state)
 
-    Logger.debug("Tree size #{current_size} - #{state[:tree_size]}")
+    Logger.debug(fn -> "Tree size #{current_size} - #{state[:tree_size]}" end)
 
     state = case current_size > state[:tree_size] do
       true ->

--- a/lib/web.ex
+++ b/lib/web.ex
@@ -97,7 +97,7 @@ defmodule Certstream.WebsocketServer do
       Logger.warn("Message drop count greater than 0 -> #{message_drop_count}")
     end
 
-    Logger.debug("Sending client #{length(payload |> List.flatten)} client frames")
+    Logger.debug(fn -> "Sending client #{length(payload |> List.flatten)} client frames" end)
 
     # Reactive our pobox active mode
     :pobox.active(box_pid, fn(msg, _) -> {{:ok, msg}, :nostate} end, :nostate)


### PR DESCRIPTION
```mix credo``` outputs following warnings.

```
  Warnings - please take a look
┃
┃ [W] ↗ Prefer lazy Logger calls.
┃       lib/web.ex:100 #(Certstream.WebsocketServer.websocket_info)
┃ [W] ↗ Prefer lazy Logger calls.
┃       lib/ct_watcher.ex:85 #(Certstream.CTWatcher.handle_info)
┃ [W] ↗ Prefer lazy Logger calls.
┃       lib/ct_watcher.ex:81 #(Certstream.CTWatcher.handle_info)
┃ [W] ↗ Prefer lazy Logger calls.
┃       lib/agents.ex:134 #(Certstream.ClientManager.broadcast_to_clients)
```

This PR fixes the warnings.
