### PR TITLE
Add remove bad ctl servers

### DIFF
--- a/lib/ct_watcher.ex
+++ b/lib/ct_watcher.ex
@@ -9,7 +9,9 @@ defmodule Certstream.CTWatcher do
     "ctserver.cnnic.cn/", "ctlog.api.venafi.com/", "ctlog.gdca.com.cn/", "ctlog.sheca.com/", "ctlog.wosign.com/",
     "ctlog2.wosign.com/", "flimsy.ct.nordu.net:8080/", "log.certly.io/", "nessie2021.ct.digicert.com/log/",
     "plausible.ct.nordu.net/", "www.certificatetransparency.cn/ct/", "ct.googleapis.com/testtube/",
-    "ct.googleapis.com/daedalus/"
+    "ct.googleapis.com/daedalus/",
+    "ct.ws.symantec.com/", "vega.ws.symantec.com/", "deneb.ws.symantec.com/", "sirius.ws.symantec.com/",
+    "log.gdca.com.cn/", "log2.gdca.com.cn/",
   ]
 
   def child_spec(log) do

--- a/lib/ct_watcher.ex
+++ b/lib/ct_watcher.ex
@@ -7,7 +7,7 @@ defmodule Certstream.CTWatcher do
     "alpha.ctlogs.org/", "clicky.ct.letsencrypt.org/", "ct.akamai.com/", "ct.filippo.io/behindthesofa/",
     "ct.gdca.com.cn/", "ct.izenpe.com/", "ct.izenpe.eus/", "ct.sheca.com/", "ct.startssl.com/", "ct.wosign.com/",
     "ctserver.cnnic.cn/", "ctlog.api.venafi.com/", "ctlog.gdca.com.cn/", "ctlog.sheca.com/", "ctlog.wosign.com/",
-    "ctlog2.wosign.com/", "flimsy.ct.nordu.net:8080/", "log.certly.io/", "nessie2021.ct.digicert.com/log/",
+    "ctlog2.wosign.com/", "flimsy.ct.nordu.net:8080/", "log.certly.io/",
     "plausible.ct.nordu.net/", "www.certificatetransparency.cn/ct/", "ct.googleapis.com/testtube/",
     "ct.googleapis.com/daedalus/",
     "ct.ws.symantec.com/", "vega.ws.symantec.com/", "deneb.ws.symantec.com/", "sirius.ws.symantec.com/",


### PR DESCRIPTION
Hi,
Some ctl servers are not functional. So the `fetch_all_logs` function never ends and more it tries again and again to connect to the nonfunctional server without try for the rest of the ctl server list.

My patch is not a real solution for this problem but until, the `fetch_all_logs` function can end and a process is created for all the ctl server list.

Beside `nessie2021.ct.digicert.com` works again.