### PR TITLE
Refactor HTTP requests + ensure we fetch all certificates. 

### DIFF
--- a/lib/ct_watcher.ex
+++ b/lib/ct_watcher.ex
@@ -34,8 +34,6 @@ defmodule Certstream.CTWatcher do
          end)
       # Filter out any blacklisted CTLs
       |> Enum.filter(&(!Enum.member?(@bad_ctl_servers, &1["url"])))
-      |> Enum.drop(3)
-      |> Enum.take(1)
       |> Enum.each(fn log ->
            DynamicSupervisor.start_child(supervisor_name, child_spec(log))
          end)

--- a/lib/ct_watcher.ex
+++ b/lib/ct_watcher.ex
@@ -1,5 +1,4 @@
 require Logger
-require IEx
 
 defmodule Certstream.CTWatcher do
   use GenServer

--- a/lib/ct_watcher.ex
+++ b/lib/ct_watcher.ex
@@ -1,4 +1,5 @@
 require Logger
+require IEx
 
 defmodule Certstream.CTWatcher do
   use GenServer
@@ -22,7 +23,19 @@ defmodule Certstream.CTWatcher do
 
   def start_and_link_watchers(name: supervisor_name) do
     Logger.info("Initializing CT Watchers...")
-    fetch_all_logs()
+    # Fetch all CT lists
+    ctl_log_info = http_request_with_retries("https://www.gstatic.com/ct/log_list/all_logs_list.json")
+
+    ctl_log_info
+      |> Map.get("logs")
+      # Replace the operator IDs with a hashmap of id/name
+      |> Enum.map(fn entry ->
+           replace_operator(entry, ctl_log_info["operators"])
+         end)
+      # Filter out any blacklisted CTLs
+      |> Enum.filter(&(!Enum.member?(@bad_ctl_servers, &1["url"])))
+      |> Enum.drop(3)
+      |> Enum.take(1)
       |> Enum.each(fn log ->
            DynamicSupervisor.start_child(supervisor_name, child_spec(log))
          end)
@@ -33,30 +46,6 @@ defmodule Certstream.CTWatcher do
       __MODULE__,
       %{:operator => log, :url => log["url"]}
     )
-  end
-
-  defp fetch_all_logs do
-    case HTTPoison.get("https://www.gstatic.com/ct/log_list/all_logs_list.json") do
-      {:ok, %HTTPoison.Response{status_code: 200} = response} ->
-        ctl_log_info = Jason.decode!(response.body)
-
-        ctl_log_info
-          |> Map.get("logs")
-          # Replace the operator IDs with a hashmap of id/name
-          |> Enum.map(&(replace_operator(&1, ctl_log_info["operators"])))
-          # Filter out any blacklisted CTLs
-          |> Enum.filter(&(!Enum.member?(@bad_ctl_servers, &1["url"])))
-
-      {:ok, response} ->
-        Logger.error("Unexpected status code #{response.status_code} fetching url https://www.gstatic.com/ct/log_list/all_logs_list.json! Sleeping for a bit and trying again...")
-        :timer.sleep(:timer.seconds(10))
-        fetch_all_logs()
-
-      {:error, %HTTPoison.Error{reason: reason}} ->
-        Logger.error("Error: #{reason}! Sleeping for 10 seconds and trying again...")
-        :timer.sleep(:timer.seconds(10))
-        fetch_all_logs()
-    end
   end
 
   defp replace_operator(log, operators) do
@@ -75,9 +64,41 @@ defmodule Certstream.CTWatcher do
   def init(state) do
     Logger.info("Worker #{inspect self()} started with url #{state[:url]}.")
 
+    # Attempt to fetch 1024 certificates, and see what the API returns. However
+    # many certs come back is what we should use as the batch size moving forward
+    # (at least in theory).
+    batch_size = http_request_with_retries("https://#{state[:url]}ct/v1/get-entries?start=0&end=1024")
+                   |> Map.get("entries")
+                   |> Enum.count
+
+    Logger.info("Worker #{inspect self()} found batch size of #{batch_size}.")
+
+    state = state
+              |> Map.put(:batch_size, batch_size)
+
     schedule_update()
 
     {:ok, state}
+  end
+
+  def http_request_with_retries(full_url, options \\ [timeout: 10_000, recv_timeout: 10_000]) do
+    # Go ask for the first 1024 entries
+    Logger.info("Sending GET request to #{full_url}")
+    case HTTPoison.get(full_url, [], options) do
+      {:ok, %HTTPoison.Response{status_code: 200} = response} ->
+        response.body
+          |> Jason.decode!
+
+      {:ok, response} ->
+        Logger.error("Unexpected status code #{response.status_code} fetching url #{full_url}! Sleeping for a bit and trying again...")
+        :timer.sleep(:timer.seconds(10))
+        http_request_with_retries(full_url, options)
+
+      {:error, %HTTPoison.Error{reason: reason}} ->
+        Logger.error("Error: #{reason}! Sleeping for 10 seconds and trying again...")
+        :timer.sleep(:timer.seconds(10))
+        http_request_with_retries(full_url, options)
+    end
   end
 
   def handle_info({:ssl_closed, _}, state) do
@@ -85,19 +106,18 @@ defmodule Certstream.CTWatcher do
     {:noreply, state}
   end
 
-
   def handle_info(:update, state) do
     Logger.debug(fn -> "Worker #{inspect self()} got tick." end)
+
+    current_size = fetch_tree_size(state)
 
     state = case state[:tree_size] do
       nil ->
         Logger.info("Worker #{inspect self()} initializing tree size.")
-        Map.put(state, :tree_size, fetch_tree_size(state))
+        Map.put(state, :tree_size, current_size)
       _ ->
         state
     end
-
-    current_size = fetch_tree_size(state)
 
     Logger.debug(fn -> "Tree size #{current_size} - #{state[:tree_size]}" end)
 
@@ -114,26 +134,6 @@ defmodule Certstream.CTWatcher do
     schedule_update()
 
     {:noreply, state}
-  end
-
-  defp fetch_update(state, start, end_) do
-    Logger.info("GETing https://#{state[:url]}ct/v1/get-entries?start=#{start}&end=#{end_}")
-
-    case HTTPoison.get("https://#{state[:url]}ct/v1/get-entries?start=#{start}&end=#{end_}", [], [timeout: 10_000, recv_timeout: 10_000]) do
-      {:ok, %HTTPoison.Response{status_code: 200} = response} ->
-        response.body
-          |> Jason.decode!
-
-      {:ok, response} ->
-        Logger.error("Unexpected status code #{response.status_code} fetching url https://#{state[:url]}ct/v1/get-entries?start=#{start}&end=#{end_}! Sleeping for a bit and trying again...")
-        :timer.sleep(10_000)
-        fetch_update(state, start, end_)
-
-      {:error, %HTTPoison.Error{reason: reason}} ->
-        Logger.error("Error: #{reason}! Sleeping for 10 seconds and trying again...")
-        :timer.sleep(:timer.seconds(10))
-        fetch_update(state, start, end_)
-    end
   end
 
   defp fetch_tree_size(state) do
@@ -159,32 +159,44 @@ defmodule Certstream.CTWatcher do
     certificate_count = (current_size - state[:tree_size])
     certificates = Enum.to_list (current_size - certificate_count)..current_size - 1
 
+    Logger.info("Certificate count - #{certificate_count} ")
     certificates
-      |> Enum.chunk_every(64)
-      |> Enum.each(
-           fn ids ->
-             update = fetch_update(state, List.first(ids), List.last(ids))
+      |> Enum.chunk_every(state[:batch_size])
+      |> Enum.each(&(fetch_and_broadcast_certs(&1, state)))
+  end
 
-             update
-               |> Map.get("entries", [])
-               |> Enum.zip(ids)
-               |> Enum.map(fn {entry, cert_index} ->
-                 parsed_entry = Certstream.CTParser.parse_entry(entry)
-                 parsed_entry
-                   |> Map.merge(
-                        %{
-                          :cert_index => cert_index,
-                          :seen => :os.system_time(:microsecond) / 1_000_000,
-                          :source => %{
-                            :url => state[:operator]["url"],
-                            :name => state[:operator]["description"],
-                          },
-                          :cert_link => "http://#{state[:operator]["url"]}ct/v1/get-entries?start=#{cert_index}&end=#{cert_index}"
-                        }
-                      )
-                 end)
-               |> Certstream.ClientManager.broadcast_to_clients
-           end)
+  def fetch_and_broadcast_certs(ids, state) do
+    Logger.debug("Attempting to retrieve #{ids |> Enum.count} entries")
+    entries = http_request_with_retries("https://#{state[:url]}ct/v1/get-entries?start=#{List.first(ids)}&end=#{List.last(ids)}")
+                |> Map.get("entries", [])
+
+    entries
+      |> Enum.zip(ids)
+      |> Enum.map(fn {entry, cert_index} ->
+        Certstream.CTParser.parse_entry(entry)
+          |> Map.merge(
+               %{
+                 :cert_index => cert_index,
+                 :seen => :os.system_time(:microsecond) / 1_000_000,
+                 :source => %{
+                   :url => state[:operator]["url"],
+                   :name => state[:operator]["description"],
+                 },
+                 :cert_link => "http://#{state[:operator]["url"]}ct/v1/get-entries?start=#{cert_index}&end=#{cert_index}"
+               }
+             )
+      end)
+      |> Certstream.ClientManager.broadcast_to_clients
+
+    entry_count = Enum.count(entries)
+    batch_count = Enum.count(ids)
+
+    # If we have *unequal* counts the API has returned less certificates than our initial batch
+    # heuristic. Drop the entires we retrieved and recurse to fetch others.
+    if entry_count != batch_count do
+      Logger.info("We didn't retrieve all the entries for this batch, fetching missing #{batch_count - entry_count} entries")
+      fetch_and_broadcast_certs(ids |> Enum.drop(Enum.count(entries)), state)
+    end
   end
 
   defp schedule_update do


### PR DESCRIPTION
This PR does a few things:
- It reorganizes the repeated `HTTPoison.get` pattern into a `http_request_with_retries` function, which will make a GET request and return a parsed JSON blob. Then it refactors things to use that function and gets rid of un-necessary functions like `fetch_all_logs`.
- It does some heuristic batching when the worker starts in order to try to determine the optimal batching size for each CT server. It does this by requesting the first 1024 (an arbitrary large number) certificates in one request and counting the response. It then uses that batch count for future requests to that server (though some, like Google's, still return odd counts)
- It fixes a bug where we're calling `fetch_tree_size()` twice which at best makes an extra request for no reason and at worst could mess up calculations for the first batch to pull down
- It breaks out the actual fetching of certificates into a function named `fetch_and_broadcast_certs`, which then recursively calls itself until all certificates are retrieved (still using the batch size from initialization)

Turns out this was a break in expectations with the RFC and has been broken basically since this project's inception https://tools.ietf.org/html/rfc6962#section-4.6 🙀