### PR TITLE
v1.4.0

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,1 @@
-html/* linguist-vendored
+frontend/* linguist-vendored

--- a/lib/application.ex
+++ b/lib/application.ex
@@ -1,4 +1,8 @@
 defmodule Certstream do
+  @moduledoc """
+  Certstream is a service for watching CT servers, parsing newly discovered certificates,
+  and broadcasting updates to connected websocket clients.
+  """
   use Application
 
   def start(_type, _args) do

--- a/lib/certificate_buffer_agent.ex
+++ b/lib/certificate_buffer_agent.ex
@@ -57,7 +57,7 @@ defmodule Certstream.CertifcateBuffer do
       fn certificates ->
         certificates
         |> List.first
-        |> Jason.encode!()
+        |> Jason.encode!(pretty: true)
       end
     )
   end
@@ -68,7 +68,7 @@ defmodule Certstream.CertifcateBuffer do
       fn certificates ->
         %{}
         |> Map.put(:messages, certificates)
-        |> Jason.encode!()
+        |> Jason.encode!(pretty: true)
       end
     )
   end

--- a/lib/certificate_buffer_agent.ex
+++ b/lib/certificate_buffer_agent.ex
@@ -8,8 +8,6 @@ defmodule Certstream.CertifcateBuffer do
     aggregated for the /example.json and /latest.json routes.
   """
 
-  @status_update_count 10_000
-
   @doc "Starts the CertificateBuffer agent and creates an ETS table for tracking the certificates processed"
   def start_link(_opts) do
     Logger.info("Starting #{__MODULE__}...")
@@ -25,7 +23,7 @@ defmodule Certstream.CertifcateBuffer do
 
   @doc "Adds a certificate update to the circular certificate buffer"
   def add_certs_to_buffer(certificates) do
-    processed_certificates_count = :ets.update_counter(:counter, :processed_certificates, length(certificates))
+    :ets.update_counter(:counter, :processed_certificates, length(certificates))
 
     Agent.update(__MODULE__, fn state ->
       state = certificates ++ state

--- a/lib/client_manager_agent.ex
+++ b/lib/client_manager_agent.ex
@@ -1,6 +1,10 @@
 require Logger
 
 defmodule Certstream.ClientManager do
+  @moduledoc """
+  An agent responsible for managing and broadcasting to websocket clients. Uses :pobox to
+  provide buffering and eventually drops messages if the backpressure isn't enough.
+  """
   use Agent
 
   def start_link(_opts) do
@@ -45,8 +49,7 @@ defmodule Certstream.ClientManager do
     Agent.get(__MODULE__, fn state ->
 
       state
-        |> Enum.map(fn {k,v} ->
-
+        |> Enum.map(fn {k, v} ->
           coerced_payload = v
                             |> Map.update!(:connect_time, &DateTime.to_iso8601/1)
                             |> Map.drop([:po_box, :is_websocket])

--- a/lib/web.ex
+++ b/lib/web.ex
@@ -1,6 +1,10 @@
 require Logger
 
 defmodule Certstream.WebsocketServer do
+  @moduledoc """
+  The main web services GenServer, responsible for spinning up cowboy and encapsulates
+  all logic for web routes/websockets.
+  """
   use GenServer
 
   # GenServer callback
@@ -51,7 +55,7 @@ defmodule Certstream.WebsocketServer do
   def init(req, state) do
     # If we have a websocket request, do the thing, otherwise just host our main HTML
     if Map.has_key?(req.headers, "upgrade") do
-      Logger.debug("New client connected #{inspect req.peer}")
+      Logger.debug(fn -> "New client connected #{inspect req.peer}" end)
       {
         :cowboy_websocket,
         req,
@@ -76,7 +80,7 @@ defmodule Certstream.WebsocketServer do
 
   def terminate(_reason, _partial_req, state) do
     if state[:is_websocket] do
-      Logger.debug("Client disconnected #{inspect state.ip_address}")
+      Logger.debug(fn -> "Client disconnected #{inspect state.ip_address}" end)
       Certstream.ClientManager.remove_client(self())
     end
   end
@@ -87,7 +91,7 @@ defmodule Certstream.WebsocketServer do
   end
 
   def websocket_handle(frame, state) do
-    Logger.debug("Client sent message #{inspect frame}")
+    Logger.debug(fn -> "Client sent message #{inspect frame}" end)
     {:ok, state}
   end
 

--- a/lib/web.ex
+++ b/lib/web.ex
@@ -29,11 +29,12 @@ defmodule Certstream.WebsocketServer do
     processed_certs = Certstream.CertifcateBuffer.get_processed_certificates
     client_json = Certstream.ClientManager.get_clients_json
 
-    workers = DynamicSupervisor.which_children(WatcherSupervisor)
-      |> Enum.reduce(%{}, fn {:undefined, pid, :worker, _module}, acc ->
-          state = :sys.get_state pid
-          Map.put(acc, state[:url], state[:processed_count] || 0)
-         end)
+    workers = WatcherSupervisor
+                |> DynamicSupervisor.which_children
+                |> Enum.reduce(%{}, fn {:undefined, pid, :worker, _module}, acc ->
+                    state = :sys.get_state pid
+                    Map.put(acc, state[:url], state[:processed_count] || 0)
+                   end)
 
     response = %{}
                |> Map.put(:processed_certificates, processed_certs)

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Certstream.Mixfile do
   def project do
     [
       app: :certstream,
-      version: "1.3.0",
+      version: "1.4.0",
       elixir: "~> 1.6",
       start_permanent: Mix.env == :prod,
       deps: deps(),


### PR DESCRIPTION
This brings a number of fixes and optimizations:
- Fixes all credo warnings
- Refactors worker initialization to not block the application initialization process while starting up, and runs the first tick between 0-3 seconds (as opposed to the current 15)
- Tweaks down tick times to 10 seconds from 15 seconds (so each CT server will be polled every 10 seconds now)
- Moves to using `Task.async_stream` with a concurrency of 5 for getting entries, so for each update as we chunk, we'll make 5 concurrent HTTP requests to retrieve entries (and keep recursing until we get all $BATCH_SIZE certificates). *NOTE* This no longer guarantees broadcast ordering for each server, but it makes retrieval much more efficient. 