### PR TITLE
Fetch log level from env var LOG_LEVEL, default to :info

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -4,7 +4,7 @@ config :certstream,
        user_agent: :default  # Defaults to "Certstream Server v{CURRENT_VERSION}"
 
 config :logger,
-       level: :info,
+       level: String.to_atom(System.get_env("LOG_LEVEL") || "info"),
        backends: [:console]
 
 config :honeybadger,


### PR DESCRIPTION
Hello!

I really like this project, and since it can be a bit verbose at times with all the GET requests log, I thought it would be great if one could configure the log level through an environment variable. 

This PR adds just that, the `LOG_LEVEL` should contain one of Erlang's Logger log levels (`info`, `warn`, etc). If `LOG_LEVEL` is not set, it defaults to `:info`, so that's not a breaking change.

What do you think?