### PR TITLE
Change base image to elixir:1.6-otp-21-alpine to close #39

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM elixir:1.6-alpine
+FROM elixir:1.6-otp-21-alpine
 
 WORKDIR /opt/app
 


### PR DESCRIPTION
_Maybe_ this should be 1.8+ given these warnings?

```
warning: the dependency :honeybadger requires Elixir "~> 1.7" but you are running on v1.6.6
warning: the dependency :httpoison requires Elixir "~> 1.8" but you are running on v1.6.6
```

But I'll defer to you on that. Thanks again

