### PR TITLE
Fix Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM elixir:1.6-alpine
+FROM elixir:1.8-alpine
 
 WORKDIR /opt/app
 


### PR DESCRIPTION
The docker container currently fails to build with the following error:

```
...SNIP...
==> honeybadger
warning: the dependency :honeybadger requires Elixir "~> 1.7" but you are running on v1.6.6
Compiling 19 files (.ex)
Generated honeybadger app
==> easy_ssl
Compiling 1 file (.ex)
Generated easy_ssl app
==> httpoison
warning: the dependency :httpoison requires Elixir "~> 1.8" but you are running on v1.6.6
Compiling 3 files (.ex)
Generated httpoison app
===> Compiling cowlib
===> Compiling cowboy
===> Compiling src/cowboy_http2.erl failed
src/cowboy_http2.erl:397: illegal pattern
src/cowboy_http2.erl:400: variable 'Exception' is unbound
src/cowboy_http2.erl:400: variable 'Stacktrace' is unbound
src/cowboy_http2.erl:504: illegal pattern
src/cowboy_http2.erl:507: variable 'Exception' is unbound
src/cowboy_http2.erl:507: variable 'Stacktrace' is unbound
src/cowboy_http2.erl:531: illegal pattern
src/cowboy_http2.erl:534: variable 'Exception' is unbound
src/cowboy_http2.erl:534: variable 'Stacktrace' is unbound
src/cowboy_http2.erl:592: illegal pattern
src/cowboy_http2.erl:595: variable 'Exception' is unbound
src/cowboy_http2.erl:595: variable 'Stacktrace' is unbound
src/cowboy_http2.erl:1124: illegal pattern
src/cowboy_http2.erl:1127: variable 'Exception' is unbound
src/cowboy_http2.erl:1127: variable 'Stacktrace' is unbound

==> certstream
** (Mix) Could not compile dependency :cowboy, "/opt/mix/rebar3 bare compile --paths "/opt/app/_build/prod/lib/*/ebin"" command failed. You can recompile this dependency with "mix deps.compile cowboy", update it with "mix deps.update cowboy" or clean it with "mix deps.clean cowboy"
The command '/bin/sh -c mix do deps.get, deps.compile' returned a non-zero code: 1
```

Bumping the base image to Elixir 1.8 resolves this.