### PR TITLE
Lower initial batch size to 512

### DIFF
--- a/lib/ct_watcher.ex
+++ b/lib/ct_watcher.ex
@@ -118,7 +118,7 @@ defmodule Certstream.CTWatcher do
                        |> Map.get("entries")
                        |> Enum.count
 
-        Logger.info("Worker #{inspect self()} (url=#{state[:url]}) found batch size of #{batch_size}.")
+        Logger.info("Worker #{inspect self()} with url #{state[:url]} found batch size of #{batch_size}.")
 
         state = Map.put(state, :batch_size, batch_size)
 
@@ -129,7 +129,7 @@ defmodule Certstream.CTWatcher do
 
         state
       rescue e ->
-        Logger.warn("Worker with state #{inspect state} blew up because #{inspect e}")
+        Logger.warn("Worker #{inspect self()} with state #{inspect state} blew up because #{inspect e}")
       end
 
     {:noreply, state}

--- a/lib/ct_watcher.ex
+++ b/lib/ct_watcher.ex
@@ -72,7 +72,7 @@ defmodule Certstream.CTWatcher do
   end
 
   def http_request_with_retries(full_url, options \\ @default_http_options) do
-    # Go ask for the first 1024 entries
+    # Go ask for the first 512 entries
     Logger.info("Sending GET request to #{full_url}")
 
     user_agent = {"User-Agent", user_agent()}
@@ -106,19 +106,19 @@ defmodule Certstream.CTWatcher do
   end
 
   def handle_info(:init, state) do
-    # On first run attempt to fetch 1024 certificates, and see what the API returns. However
+    # On first run attempt to fetch 512 certificates, and see what the API returns. However
     # many certs come back is what we should use as the batch size moving forward (at least
     # in theory).
     state =
       try do
-        batch_size = "https://#{state[:url]}ct/v1/get-entries?start=0&end=1024"
+        batch_size = "https://#{state[:url]}ct/v1/get-entries?start=0&end=511"
                        |> HTTPoison.get!
                        |> Map.get(:body)
                        |> Jason.decode!
                        |> Map.get("entries")
                        |> Enum.count
 
-        Logger.info("Worker #{inspect self()} found batch size of #{batch_size}.")
+        Logger.info("Worker #{inspect self()} (url=#{state[:url]}) found batch size of #{batch_size}.")
 
         state = Map.put(state, :batch_size, batch_size)
 


### PR DESCRIPTION
This lowers the initial batch size from 1024 to 512.

With the current batch size seven of the Qihoo 360 workers are failing to start with: `request failed: rpc error: code = ResourceExhausted desc = grpc: received message larger than max`. Lowering the initial batch size resolves this.

Most logs support a max of 32 or 256, although Cloudflare and Comodo both support larger sizes of 1024 and 1001 respectively.

<details>
<summary>Full logs</summary>

The following is the full error message for the workers failing to start with this error:

```
17:46:06.482 [warn]  Worker with state %{operator: %{"description" => "Qihoo 360 v1 2020", "key" => "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEDkQZn1WqxqWyWHG86i14qbZ+yk/17Q8SWeubOJw6jQdNJRh4zJwD3mGTZIQge3T6QOgzChWUJA3wYztSx+M/gg==", "maximum_merge_delay" => 86400, "operated_by" => %{"id" => 19, "name" => "Qihoo 360"}, "url" => "ct.browser.360.cn/v1/2020/"}, url: "ct.browser.360.cn/v1/2020/"} blew up because %Jason.DecodeError{data: "Forbidden\nbackend GetLeavesByRange request failed: rpc error: code = ResourceExhausted desc = grpc: received message larger than max (5223916 vs. 4194304)\n", position: 0, token: nil}
17:46:06.595 [warn]  Worker with state %{operator: %{"description" => "Qihoo 360 v1 2023", "key" => "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEpvIPBkpPfcg4boasja6srvBflgDAznTytKjNWPX151jP/EaRZmNOFBavgBI2oxlQabgYG11YHdwH+FHnyVTaNw==", "maximum_merge_delay" => 86400, "operated_by" => %{"id" => 19, "name" => "Qihoo 360"}, "url" => "ct.browser.360.cn/v1/2023/"}, url: "ct.browser.360.cn/v1/2023/"} blew up because %Jason.DecodeError{data: "Forbidden\nbackend GetLeavesByRange request failed: rpc error: code = ResourceExhausted desc = grpc: received message larger than max (5238883 vs. 4194304)\n", position: 0, token: nil}
17:46:06.665 [warn]  Worker with state %{operator: %{"description" => "Qihoo 360 2020", "key" => "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE+nuP0XjE36o+HfjS9IKnDItCnp3Tn9NafZpJ/8GHvLm+Z/AXY7FuN3L4LPXRrlTydBLt60OqzktHoJ4t4fNodg==", "maximum_merge_delay" => 86400, "operated_by" => %{"id" => 19, "name" => "Qihoo 360"}, "url" => "ct.browser.360.cn/2020/"}, url: "ct.browser.360.cn/2020/"} blew up because %Jason.DecodeError{data: "Forbidden\nbackend GetLeavesByRange request failed: rpc error: code = ResourceExhausted desc = grpc: received message larger than max (4791518 vs. 4194304)\n", position: 0, token: nil}
17:46:06.672 [warn]  Worker with state %{operator: %{"description" => "Qihoo 360 2022", "key" => "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEQ4UlFLE3vxDHtsqO5s6kNURSyaLK9bHV5+zDXTQzwiUJdTFKxE85L5uvYvobuyZpySo7GXYyopL4Exsrm4HJMA==", "maximum_merge_delay" => 86400, "operated_by" => %{"id" => 19, "name" => "Qihoo 360"}, "url" => "ct.browser.360.cn/2022/"}, url: "ct.browser.360.cn/2022/"} blew up because %Jason.DecodeError{data: "Forbidden\nbackend GetLeavesByRange request failed: rpc error: code = ResourceExhausted desc = grpc: received message larger than max (5051873 vs. 4194304)\n", position: 0, token: nil}
17:46:06.698 [warn]  Worker with state %{operator: %{"description" => "Qihoo 360 v1 2022", "key" => "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEAvqcteHHGEZCE5kSvEpQIPD4fXsEFHYt1/EViSMv7QDtBHTpK94IZSScZLOWk5fpvGIB/6ibVzR5MCW/NSMd/A==", "maximum_merge_delay" => 86400, "operated_by" => %{"id" => 19, "name" => "Qihoo 360"}, "url" => "ct.browser.360.cn/v1/2022/"}, url: "ct.browser.360.cn/v1/2022/"} blew up because %Jason.DecodeError{data: "Forbidden\nbackend GetLeavesByRange request failed: rpc error: code = ResourceExhausted desc = grpc: received message larger than max (5183479 vs. 4194304)\n", position: 0, token: nil}
17:46:06.906 [warn]  Worker with state %{operator: %{"description" => "Qihoo 360 v1 2021", "key" => "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEB1OT52y/+wSUqaHfJh6/BvTD27mlZr6qZddkis7McckOaXx5cU3I/fBx90p3j1tWqEArVuiKmHHAvu82l9Uz2w==", "maximum_merge_delay" => 86400, "operated_by" => %{"id" => 19, "name" => "Qihoo 360"}, "url" => "ct.browser.360.cn/v1/2021/"}, url: "ct.browser.360.cn/v1/2021/"} blew up because %Jason.DecodeError{data: "Forbidden\nbackend GetLeavesByRange request failed: rpc error: code = ResourceExhausted desc = grpc: received message larger than max (5235355 vs. 4194304)\n", position: 0, token: nil}
17:46:06.986 [warn]  Worker with state %{operator: %{"description" => "Qihoo 360 2021", "key" => "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEYFtlqKC59Iy+N1sWaUktnSNpbhrrL4VMiaqdDrQu/3hOnxOJiXFlkSYQjBoHDCVA5iC9pu8+1DsrmNsv5FIMDw==", "maximum_merge_delay" => 86400, "operated_by" => %{"id" => 19, "name" => "Qihoo 360"}, "url" => "ct.browser.360.cn/2021/"}, url: "ct.browser.360.cn/2021/"} blew up because %Jason.DecodeError{data: "Forbidden\nbackend GetLeavesByRange request failed: rpc error: code = ResourceExhausted desc = grpc: received message larger than max (4752135 vs. 4194304)\n", position: 0, token: nil}
```

</details>