### PR TITLE
Greatly simplify the serialization process and remove chain from the main stream

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Certstream.Mixfile do
   def project do
     [
       app: :certstream,
-      version: "1.5.0",
+      version: "1.6.0",
       elixir: "~> 1.6",
       start_permanent: Mix.env == :prod,
       deps: deps(),


### PR DESCRIPTION
This PR changes the primary stream for certstream to not include the `chain` attribute, only shipping the leaf certificate which is likely more useful for most people. Plus this logic was way more complicated than it needed to be with no real reason, so its greatly simplified now. 

Fixes #47 

```
❯ certstream --url ws://127.0.0.1:4000/ --json | jq .
[INFO:certstream] 2020-12-05 16:13:19,246 - Connection established to CertStream! Listening for events...
{
  "data": {
    "cert_index": 85645731,
    "cert_link": "http://oak.ct.letsencrypt.org/2021/ct/v1/get-entries?start=85645731&end=85645731",
    "leaf_cert": {
      "all_domains": [
        "autodiscover.duplica.com.hk",
        "cpanel.duplica.com.hk",
        "duplica.com.hk",
        "mail.duplica.com.hk",
        "webdisk.duplica.com.hk",
        "webmail.duplica.com.hk",
        "www.duplica.com.hk"
      ],
      "extensions": {
        "authorityInfoAccess": "OCSP - URI:http://ocsp.comodoca.com\nCA Issuers - URI:http://crt.comodoca.com/cPanelIncCertificationAuthority.crt\n",
        "authorityKeyIdentifier": "keyid:7E:03:5A:65:41:6B:A7:7E:0A:E1:B8:9D:08:EA:1D:8E:1D:6A:C7:65\n",
        "basicConstraints": "CA:FALSE",
        "certificatePolicies": "Policy: 2.23.140.1.2.1\nPolicy: 1.3.6.1.4.1.6449.1.2.2.52\n  CPS: https://sectigo.com/CPS",
        "crlDistributionPoints": "Full Name:\n URI:http://crl.comodoca.com/cPanelIncCertificationAuthority.crl",
        "ctlPoisonByte": true,
        "extendedKeyUsage": "TLS Web server authentication, TLS Web client authentication",
        "keyUsage": "Digital Signature, Key Encipherment",
        "subjectAltName": "DNS:www.duplica.com.hk, DNS:webmail.duplica.com.hk, DNS:webdisk.duplica.com.hk, DNS:mail.duplica.com.hk, DNS:cpanel.duplica.com.hk, DNS:autodiscover.duplica.com.hk, DNS:duplica.com.hk",
        "subjectKeyIdentifier": "AF:95:AA:B5:BB:EF:73:5A:F0:63:5C:0F:DE:7B:36:1B:A3:C4:F6:A0"
      },
      "fingerprint": "2E:4A:15:41:66:B1:DF:C3:A1:E9:14:48:BC:5E:EB:16:25:3A:E3:4F",
      "issuer": {
        "C": "US",
        "CN": "cPanel, Inc. Certification Authority",
        "L": "Houston",
        "O": "cPanel, Inc.",
        "OU": null,
        "ST": "TX",
        "aggregated": "/C=US/CN=cPanel, Inc. Certification Authority/L=Houston/O=cPanel, Inc./ST=TX",
        "emailAddress": null
      },
      "not_after": 1614988799,
      "not_before": 1607126400,
      "serial_number": "63ADAA91493286184EB6D74A21E6B580",
      "signature_algorithm": "sha256, rsa",
      "subject": {
        "C": null,
        "CN": "duplica.com.hk",
        "L": null,
        "O": null,
        "OU": null,
        "ST": null,
        "aggregated": "/CN=duplica.com.hk",
        "emailAddress": null
      }
    },
    "seen": 1607202799.950519,
    "source": {
      "name": "Let's Encrypt 'Oak2021' log",
      "url": "oak.ct.letsencrypt.org/2021/"
    },
    "update_type": "PrecertLogEntry"
  },
  "message_type": "certificate_update"
}
```