### PR TITLE
Fix content-type header

### DIFF
--- a/lib/certstream/web.ex
+++ b/lib/certstream/web.ex
@@ -17,14 +17,14 @@ defmodule Certstream.WebsocketServer do
 
   # /example.json handler
   def init(req, [:example_json]) do
-    res = :cowboy_req.reply(200, %{'content_type' => 'application/json'},
+    res = :cowboy_req.reply(200, %{'content-type' => 'application/json'},
                             Certstream.CertifcateBuffer.get_example_json(), req)
     {:ok, res, %{}}
   end
 
   # /latest.json handler
   def init(req, [:latest_json]) do
-    res = :cowboy_req.reply(200, %{'content_type' => 'application/json'},
+    res = :cowboy_req.reply(200, %{'content-type' => 'application/json'},
                             Certstream.CertifcateBuffer.get_latest_json(), req)
     {:ok, res, %{}}
   end
@@ -50,7 +50,7 @@ defmodule Certstream.WebsocketServer do
 
     res = :cowboy_req.reply(
       200,
-      %{'content_type' => 'application/json'},
+      %{'content-type' => 'application/json'},
       response,
       req
     )
@@ -78,7 +78,7 @@ defmodule Certstream.WebsocketServer do
       Instruments.increment("certstream.index_load", 1, tags: ["ip:#{state[:ip_address]}"])
       res = :cowboy_req.reply(
         200,
-        %{'content_type' => 'text/html'},
+        %{'content-type' => 'text/html'},
         File.read!("frontend/dist/index.html"),
         req
       )


### PR DESCRIPTION
`web.ex` is currently setting a `content_type` header instead of setting the `content-type` header.

Pages still appear to load fine in most browsers (e.g., Chrome) but setting the correct header will fix some edge cases where content isn't rendered properly.