### PR TITLE
Follow redirects

### DIFF
--- a/lib/certstream/ct_watcher.ex
+++ b/lib/certstream/ct_watcher.ex
@@ -9,7 +9,7 @@ defmodule Certstream.CTWatcher do
   use GenServer
   use Instruments
 
-  @default_http_options [timeout: 10_000, recv_timeout: 10_000, ssl: [{:versions, [:'tlsv1.2']}]]
+  @default_http_options [timeout: 10_000, recv_timeout: 10_000, ssl: [{:versions, [:'tlsv1.2']}], follow_redirect: true]
 
   def child_spec(log) do
     %{
@@ -112,7 +112,7 @@ defmodule Certstream.CTWatcher do
     state =
       try do
         batch_size = "https://#{state[:url]}ct/v1/get-entries?start=0&end=511"
-                       |> HTTPoison.get!
+                       |> HTTPoison.get!([], @default_http_options)
                        |> Map.get(:body)
                        |> Jason.decode!
                        |> Map.get("entries")


### PR DESCRIPTION
Adds `follow_redirect: true` to `@default_http_options` and passes those options for the first GET for each log.

This resolves these three warnings:

```
02:19:37.858 [warn]  Worker #PID<0.376.0> with state %{operator: %{"description" => "CNNIC CT log", "key" => "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAv7UIYZopMgTTJWPp2IXhhuAf1l6a9zM7gBvntj5fLaFm9pVKhKYhVnno94XuXeN8EsDgiSIJIj66FpUGvai5samyetZhLocRuXhAiXXbDNyQ4KR51tVebtEq2zT0mT9liTtGwiksFQccyUsaVPhsHq9gJ2IKZdWauVA2Fm5x9h8B9xKn/L/2IaMpkIYtd967TNTP/dLPgixN1PLCLaypvurDGSVDsuWabA3FHKWL9z8wr7kBkbdpEhLlg2H+NAC+9nGKx+tQkuhZ/hWR65aX+CNUPy2OB9/u2rNPyDydb988LENXoUcMkQT0dU3aiYGkFAY0uZjD2vH97TM20xYtNQIDAQAB", "maximum_merge_delay" => 86400, "operated_by" => %{"id" => 10, "name" => "CNNIC"}, "url" => "ctserver.cnnic.cn/"}, url: "ctserver.cnnic.cn/"} blew up because %HTTPoison.Error{id: nil, reason: {:tls_alert, {:unknown_ca, 'TLS client: In state certify at ssl_handshake.erl:1895 generated CLIENT ALERT: Fatal - Unknown CA\n'}}}
02:19:38.538 [warn]  Worker #PID<0.387.0> with state %{operator: %{"description" => "Let's Encrypt 'Oak2019' log", "key" => "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEFkqNKRuZ+Z8IOsnNJrUZ8gwp+KKGOdQrJ/HKhSadK/SJuoCc9+dxQ7awpmWIMr9SKcQeG5uRzG1kVSyFN4Wfcw==", "maximum_merge_delay" => 86400, "operated_by" => %{"id" => 17, "name" => "Let's Encrypt"}, "url" => "oak.ct.letsencrypt.org/2019/"}, url: "oak.ct.letsencrypt.org/2019/"} blew up because %Jason.DecodeError{data: "<html>\r\n<head><title>301 Moved Permanently</title></head>\r\n<body>\r\n<center><h1>301 Moved Permanently</h1></center>\r\n<hr><center>nginx</center>\r\n</body>\r\n</html>\r\n", position: 0, token: nil}
02:19:38.554 [warn]  Worker #PID<0.388.0> with state %{operator: %{"description" => "Let's Encrypt 'Oak2020' log", "key" => "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEfzb42Zdr/h7hgqgDCo1vrNJqGqbcUvJGJEER9DDqp19W/wFSB0l166hD+U5cAXchpH8ZkBNUuvOHS0OnJ4oJrQ==", "maximum_merge_delay" => 86400, "operated_by" => %{"id" => 17, "name" => "Let's Encrypt"}, "url" => "oak.ct.letsencrypt.org/2020/"}, url: "oak.ct.letsencrypt.org/2020/"} blew up because %Jason.DecodeError{data: "<html>\r\n<head><title>301 Moved Permanently</title></head>\r\n<body>\r\n<center><h1>301 Moved Permanently</h1></center>\r\n<hr><center>nginx</center>\r\n</body>\r\n</html>\r\n", position: 0, token: nil}
```

The last two are resolved by following the redirect, I believe the other is because we're now using TLS 1.2 for the first request?