### PR TITLE
Changed all_log_list URL and adapted file format

### DIFF
--- a/lib/certstream/ct_watcher.ex
+++ b/lib/certstream/ct_watcher.ex
@@ -22,19 +22,21 @@ defmodule Certstream.CTWatcher do
   def start_and_link_watchers(name: supervisor_name) do
     Logger.info("Initializing CT Watchers...")
     # Fetch all CT lists
-    ctl_log_info = "https://www.gstatic.com/ct/log_list/all_logs_list.json"
+    ctl_log_info = "https://www.gstatic.com/ct/log_list/v3/all_logs_list.json"
                      |> HTTPoison.get!([], @default_http_options)
                      |> Map.get(:body)
                      |> Jason.decode!
 
+
     ctl_log_info
-      |> Map.get("logs")
-      # Replace the operator IDs with a hashmap of id/name
-      |> Enum.map(fn entry ->
-           replace_operator(entry, ctl_log_info["operators"])
-         end)
-      |> Enum.each(fn log ->
-           DynamicSupervisor.start_child(supervisor_name, child_spec(log))
+      |> Map.get("operators")
+      |> Enum.each(fn operator ->
+            operator
+            |> Map.get("logs")
+            |> Enum.each(fn log -> 
+                log = Map.put(log, "operator_name", operator["name"])
+                DynamicSupervisor.start_child(supervisor_name, child_spec(log))
+            end)
          end)
   end
 
@@ -42,19 +44,6 @@ defmodule Certstream.CTWatcher do
     GenServer.start_link(
       __MODULE__,
       %{:operator => log, :url => log["url"]}
-    )
-  end
-
-  defp replace_operator(log, operators) do
-    Map.replace!(log,
-      "operated_by",
-      Enum.find(
-        operators,
-        fn operator ->
-          log["operated_by"]
-            |> List.first == operator["id"]
-        end
-      )
     )
   end
 
@@ -95,7 +84,7 @@ defmodule Certstream.CTWatcher do
   end
 
   def get_tree_size(state) do
-    "https://#{state[:url]}ct/v1/get-sth"
+    "#{state[:url]}ct/v1/get-sth"
       |> http_request_with_retries
       |> Map.get("tree_size")
   end
@@ -109,9 +98,10 @@ defmodule Certstream.CTWatcher do
     # On first run attempt to fetch 512 certificates, and see what the API returns. However
     # many certs come back is what we should use as the batch size moving forward (at least
     # in theory).
+
     state =
       try do
-        batch_size = "https://#{state[:url]}ct/v1/get-entries?start=0&end=511"
+        batch_size = "#{state[:url]}ct/v1/get-entries?start=0&end=511"
                        |> HTTPoison.get!([], @default_http_options)
                        |> Map.get(:body)
                        |> Jason.decode!
@@ -148,8 +138,8 @@ defmodule Certstream.CTWatcher do
 
         cert_count = current_tree_size - state[:tree_size]
         Instruments.increment("certstream.worker", cert_count, tags: ["url:#{state[:url]}"])
-        Instruments.increment("certstream.aggregate_owners_count", cert_count, tags: [~s(owner:#{state[:operator]["operated_by"]["name"]})])
-
+        Instruments.increment("certstream.aggregate_owners_count", cert_count, tags: [~s(owner:#{state[:operator]["operator_name"]})])
+        
         broadcast_updates(state, current_tree_size)
 
         state
@@ -178,7 +168,7 @@ defmodule Certstream.CTWatcher do
 
   def fetch_and_broadcast_certs(ids, state) do
     Logger.debug(fn -> "Attempting to retrieve #{ids |> Enum.count} entries" end)
-    entries = "https://#{state[:url]}ct/v1/get-entries?start=#{List.first(ids)}&end=#{List.last(ids)}"
+    entries = "#{state[:url]}ct/v1/get-entries?start=#{List.first(ids)}&end=#{List.last(ids)}"
                 |> http_request_with_retries
                 |> Map.get("entries", [])
 


### PR DESCRIPTION
certstream-server relies on the URL `https://www.gstatic.com/ct/log_list/all_logs_list.json` which went offline. 
I replaced this URL with the V3 URL and adapted the file format. 